### PR TITLE
Vars and namespaces with specified metadata keys can be excluded

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,36 @@ clj_kondo/impl/analyzer.clj:1473:1: error: clj-kondo.impl.analyzer/analyze-ns-un
 
 Comparing two jars locally:
 ```
-clj -Mapi-diff api-diff :path1 ./my-jar-v1.2.jar :path2 ./my-jar-v1.3.jar
+clj -M:api-diff :path1 ./my-jar-v1.2.jar :path2 ./my-jar-v1.3.jar
 ```
 
 or via tool usage:
 
 ```
 $ clj -Tapi-diff api-diff :lib clj-kondo/clj-kondo :v1 '"2021.09.25"' :v2 '"2021.09.15"'
+```
+
+Optional exclusions:
+
+- `:exclude-meta`: exclude namespaces and vars with specified metadata keyword, repeat for multiple
+
+Some libraries use `:no-doc` metadata to mark which namespaces and vars are not part of their documented public API.
+Use `:exclude-meta` to diff only the public API of these libraries:
+
+```
+$ clojure -M:api-diff :lib zprint/zprint :v1 0.4.16 :v2 1.1.2 :exclude-meta no-doc
+zprint/rewrite.cljc:54:1: error: zprint.rewrite/sort-val was removed.
+zprint/rewrite.cljc:90:1: error: zprint.rewrite/sort-down was removed.
+zprint/rewrite.cljc:29:1: error: zprint.rewrite/prewalk was removed.
+zprint/rewrite.cljc:44:1: error: zprint.rewrite/get-sortable was removed.
+```
+
+Other libraries use `:skip-wiki`, here's an example that excludes vars and namespaces that have either `:no-doc` or `:skip-wiki` metadata:
+
+```
+$ clojure -M:api-diff :lib org.clojure/spec.alpha :v1 0.1.108 :v2 0.2.194 \
+   :exclude-meta skip-wiki :exclude-meta no-doc
+clojure/spec/alpha.clj:348:1: error: clojure.spec.alpha/map-spec was removed.
 ```
 
 ## How it works

--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,9 @@
-{:deps {clj-kondo/clj-kondo {:mvn/version "2021.09.25"}
+{:deps {clj-kondo/clj-kondo {:mvn/version "2021.10.19"}
         org.clojure/tools.deps.alpha {:mvn/version "0.12.1048"}
         org.slf4j/slf4j-nop {:mvn/version "1.7.30"}}
  :tools/usage
  {:ns-default borkdude.api-diff} :aliases {
- :test ;; added by neil  
+ :test ;; added by neil
  {:extra-paths ["test"]
   :extra-deps {io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}

--- a/src/borkdude/api_diff.clj
+++ b/src/borkdude/api_diff.clj
@@ -54,7 +54,8 @@
 
   (let [path1 (or path1 (path lib v1))
         path2 (or path2 (path lib v2))
-        vars-1 (vars path1 exclude-meta)
+        vars-1 (->> (vars path1 exclude-meta)
+                    (sort-by (juxt :ns :row)))
         vars-2 (vars path2 exclude-meta)
         compare-group-1 (group vars-1)
         compare-group-2 (group vars-2)

--- a/src/borkdude/api_diff.clj
+++ b/src/borkdude/api_diff.clj
@@ -1,6 +1,7 @@
 (ns borkdude.api-diff
   (:require
    [clj-kondo.core :as clj-kondo]
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.tools.deps.alpha :as tda]
    [clojure.tools.deps.alpha.util.maven :as mvn]))
@@ -48,12 +49,19 @@
 (defn var-symbol [[k v]]
   (str k "/" v))
 
+
+(defn- force-os-path-syntax
+  "see https://github.com/clj-kondo/clj-kondo/issues/1438
+  can turf if/when this issue is fixed"
+  [path]
+  (some-> path io/file str))
+
 (defn api-diff [{:keys [lib v1 v2
                         path1 path2
                         exclude-meta]}]
 
-  (let [path1 (or path1 (path lib v1))
-        path2 (or path2 (path lib v2))
+  (let [path1 (or (force-os-path-syntax path1) (path lib v1))
+        path2 (or (force-os-path-syntax path2) (path lib v2))
         vars-1 (->> (vars path1 exclude-meta)
                     (sort-by (juxt :ns :row)))
         vars-2 (vars path2 exclude-meta)

--- a/test-resources/newer/example.clj
+++ b/test-resources/newer/example.clj
@@ -7,6 +7,11 @@
 ;; this was public, should appear as removed
 (defn- becomes-private [])
 
+;; this was not marked with no-doc in older
+(defn ^:no-doc becomes-nodoc [])
+
 (def x 1)
 ;; (def y 2)
 (def ^:deprecated z 3)
+
+(defn ^:no-doc nodoc-changes [x y] (+ x y))

--- a/test-resources/older/example.clj
+++ b/test-resources/older/example.clj
@@ -5,6 +5,12 @@
 (def ^:private private-defa 3)
 (defn becomes-private [])
 
+(defn becomes-nodoc [])
+
 (def x 1)
 (def y 2)
 (def z 3)
+
+(defn ^:no-doc nodoc-changes [x] x)
+
+(defn ^:skip-wiki skip-wiki [])

--- a/test-resources/older/other.clj
+++ b/test-resources/older/other.clj
@@ -1,0 +1,3 @@
+(ns ^:no-doc other)
+
+(defn other-x [])

--- a/test/borkdude/api_diff_test.clj
+++ b/test/borkdude/api_diff_test.clj
@@ -3,6 +3,17 @@
             [clojure.string :as str]
             [clojure.test :as t :refer [deftest testing is]]))
 
+(defn- osify [lines]
+  (mapv (fn [l]
+          (if (str/starts-with? l "test-resources")
+            (let [[p r] (str/split l #" " 2)]
+              (str
+               (str/replace p "/" (System/getProperty "file.separator"))
+               " "
+               r))
+            l))
+        lines))
+
 (deftest diff-test
   (testing "libs"
     (let [out (with-out-str
@@ -15,24 +26,35 @@
                                            ":path2" "test-resources/newer")
                            with-out-str
                            str/split-lines)]
-      (is (= ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
-              "test-resources/older/example.clj:11:1: error: example/y was removed."
-              "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
-              "test-resources/older/example.clj:14:1: error: Arity 1 of example/nodoc-changes was removed."
-              "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."
-              "test-resources/older/other.clj:3:1: error: other/other-x was removed." ]
+      (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
+                     "test-resources/older/example.clj:11:1: error: example/y was removed."
+                     "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
+                     "test-resources/older/example.clj:14:1: error: Arity 1 of example/nodoc-changes was removed."
+                     "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."
+                     "test-resources/older/other.clj:3:1: error: other/other-x was removed."])
              actual-lines)))
+    (testing "files"
+      (let [actual-lines (-> (api-diff/-main ":path1" "test-resources/older/example.clj"
+                                             ":path2" "test-resources/newer/example.clj")
+                             with-out-str
+                             str/split-lines)]
+        (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
+                       "test-resources/older/example.clj:11:1: error: example/y was removed."
+                       "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
+                       "test-resources/older/example.clj:14:1: error: Arity 1 of example/nodoc-changes was removed."
+                       "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."])
+               actual-lines))))
     (testing "exclude-meta single"
       (let [actual-lines (-> (api-diff/-main ":path1" "test-resources/older"
                                              ":path2" "test-resources/newer"
                                              ":exclude-meta" ":no-doc")
                              with-out-str
                              str/split-lines)]
-        (is (= ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
-                "test-resources/older/example.clj:8:1: error: example/becomes-nodoc was removed."
-                "test-resources/older/example.clj:11:1: error: example/y was removed."
-                "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
-                "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."]
+        (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
+                       "test-resources/older/example.clj:8:1: error: example/becomes-nodoc was removed."
+                       "test-resources/older/example.clj:11:1: error: example/y was removed."
+                       "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
+                       "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."])
                actual-lines))))
     (testing "exclude-meta multiple"
       (let [actual-lines (-> (api-diff/-main ":path1" "test-resources/older"
@@ -41,8 +63,9 @@
                                              ":exclude-meta" ":skip-wiki")
                              with-out-str
                              str/split-lines)]
-        (is (= ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
-                "test-resources/older/example.clj:8:1: error: example/becomes-nodoc was removed."
-                "test-resources/older/example.clj:11:1: error: example/y was removed."
-                "test-resources/older/example.clj:12:1: warning: example/z was deprecated."]
+        (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
+                       "test-resources/older/example.clj:8:1: error: example/becomes-nodoc was removed."
+                       "test-resources/older/example.clj:11:1: error: example/y was removed."
+                       "test-resources/older/example.clj:12:1: warning: example/z was deprecated."])
                actual-lines))))))
+;; => #'borkdude.api-diff-test/diff-test

--- a/test/borkdude/api_diff_test.clj
+++ b/test/borkdude/api_diff_test.clj
@@ -1,19 +1,48 @@
 (ns borkdude.api-diff-test
-  (:require [borkdude.api-diff :as api-diff :refer [api-diff]]
+  (:require [borkdude.api-diff :as api-diff]
             [clojure.string :as str]
-            [clojure.test :as t :refer [deftest is]]))
+            [clojure.test :as t :refer [deftest testing is]]))
 
 (deftest diff-test
-  (let [out (with-out-str
-             (api-diff {:lib 'clj-kondo/clj-kondo
-                        :v1 "2021.09.25"
-                        :v2 "2021.09.15"}))]
-    (is (str/includes? out "clj-kondo.core/config-hash was removed")))
-  (let [out (with-out-str
-              (api-diff {:path1 "test-resources/older.clj"
-                         :path2 "test-resources/newer.clj"}))
-        actual-lines (str/split-lines out)]
-    (is (= ["test-resources/older.clj:6:1: error: example/becomes-private was removed."
-            "test-resources/older.clj:9:1: error: example/y was removed."
-            "test-resources/older.clj:10:1: warning: example/z was deprecated."]
-           actual-lines))))
+  (testing "libs"
+    (let [out (with-out-str
+                (api-diff/-main ":lib" "clj-kondo/clj-kondo"
+                                ":v1" "2021.09.25"
+                                ":v2" "2021.09.15"))]
+      (is (str/includes? out "clj-kondo.core/config-hash was removed"))))
+  (testing "paths"
+    (let [actual-lines (-> (api-diff/-main ":path1" "test-resources/older"
+                                           ":path2" "test-resources/newer")
+                           with-out-str
+                           str/split-lines)]
+      (is (= ["test-resources/older/other.clj:3:1: error: other/other-x was removed."
+              "test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
+              "test-resources/older/example.clj:11:1: error: example/y was removed."
+              "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
+              "test-resources/older/example.clj:14:1: error: Arity 1 of example/nodoc-changes was removed."
+              "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."]
+             actual-lines)))
+    (testing "exclude-meta single"
+      (let [actual-lines (-> (api-diff/-main ":path1" "test-resources/older"
+                                             ":path2" "test-resources/newer"
+                                             ":exclude-meta" ":no-doc")
+                             with-out-str
+                             str/split-lines)]
+        (is (= ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
+                "test-resources/older/example.clj:8:1: error: example/becomes-nodoc was removed."
+                "test-resources/older/example.clj:11:1: error: example/y was removed."
+                "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
+                "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."]
+               actual-lines))))
+    (testing "exclude-meta multiple"
+      (let [actual-lines (-> (api-diff/-main ":path1" "test-resources/older"
+                                             ":path2" "test-resources/newer"
+                                             ":exclude-meta" ":no-doc"
+                                             ":exclude-meta" ":skip-wiki")
+                             with-out-str
+                             str/split-lines)]
+        (is (= ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
+                "test-resources/older/example.clj:8:1: error: example/becomes-nodoc was removed."
+                "test-resources/older/example.clj:11:1: error: example/y was removed."
+                "test-resources/older/example.clj:12:1: warning: example/z was deprecated."]
+               actual-lines))))))

--- a/test/borkdude/api_diff_test.clj
+++ b/test/borkdude/api_diff_test.clj
@@ -15,12 +15,12 @@
                                            ":path2" "test-resources/newer")
                            with-out-str
                            str/split-lines)]
-      (is (= ["test-resources/older/other.clj:3:1: error: other/other-x was removed."
-              "test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
+      (is (= ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
               "test-resources/older/example.clj:11:1: error: example/y was removed."
               "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
               "test-resources/older/example.clj:14:1: error: Arity 1 of example/nodoc-changes was removed."
-              "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."]
+              "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."
+              "test-resources/older/other.clj:3:1: error: other/other-x was removed." ]
              actual-lines)))
     (testing "exclude-meta single"
       (let [actual-lines (-> (api-diff/-main ":path1" "test-resources/older"


### PR DESCRIPTION
I made an attempt to not affect current performance when
:exclude-meta option is not specified.

To support this change:
- extended our test-resources example
- upgraded to current clj-kondo (for meta analysis data)
- added command line support for repeating options and keyword values
- because command line parsing is more complex, tests now invoke
  api-diff/-main instead of api-diff/api-diff

Also:
- added the most minimal support for failing on bad cmd line options

Closes #4