### PR TITLE
Share reason why target is no longer visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ arities.  To see what was added in a newer version, just swap `:v1` and `:v2`
 (for now):
 
 ```
-clj -M:api-diff :lib clj-kondo/clj-kondo :v1 2021.09.25 :v2 2021.09.15
-clj_kondo/core.clj:213:1: error: clj-kondo.core/config-hash was removed.
 clj_kondo/core.clj:205:1: error: clj-kondo.core/resolve-config was removed.
+clj_kondo/core.clj:213:1: error: clj-kondo.core/config-hash was removed.
 clj_kondo/impl/analyzer.clj:1473:1: error: clj-kondo.impl.analyzer/analyze-ns-unmap was removed.
 ```
 
@@ -66,19 +65,25 @@ Use `:exclude-meta` to diff only the public API of these libraries:
 
 ```
 $ clojure -M:api-diff :lib zprint/zprint :v1 0.4.16 :v2 1.1.2 :exclude-meta no-doc
-zprint/rewrite.cljc:54:1: error: zprint.rewrite/sort-val was removed.
-zprint/rewrite.cljc:90:1: error: zprint.rewrite/sort-down was removed.
-zprint/rewrite.cljc:29:1: error: zprint.rewrite/prewalk was removed.
-zprint/rewrite.cljc:44:1: error: zprint.rewrite/get-sortable was removed.
+zprint/rewrite.cljc:29:1: warning: zprint.rewrite/prewalk now has meta [:no-doc].
+zprint/rewrite.cljc:44:1: warning: zprint.rewrite/get-sortable now has meta [:no-doc].
+zprint/rewrite.cljc:54:1: warning: zprint.rewrite/sort-val now has meta [:no-doc].
+zprint/rewrite.cljc:90:1: warning: zprint.rewrite/sort-down now has meta [:no-doc].
 ```
 
-Other libraries use `:skip-wiki`, here's an example that excludes vars and namespaces that have either `:no-doc` or `:skip-wiki` metadata:
-
+Other libraries use `:skip-wiki`. Let's first compare 2 versions of spec.alpha with no exclusions:
+```
+$ clojure -M:api-diff :lib org.clojure/spec.alpha :v1 0.1.108 :v2 0.2.194 
+clojure/spec/alpha.clj:348:1: error: clojure.spec.alpha/map-spec was removed.
+clojure/spec/alpha.clj:1360:1: error: clojure.spec.alpha/amp-impl arity 3 was removed.
+```
+Now let's repeat the run with the knowledge that this library use metadata to exclude vars from its public API:
 ```
 $ clojure -M:api-diff :lib org.clojure/spec.alpha :v1 0.1.108 :v2 0.2.194 \
    :exclude-meta skip-wiki :exclude-meta no-doc
 clojure/spec/alpha.clj:348:1: error: clojure.spec.alpha/map-spec was removed.
 ```
+Now we only see the relevant changes to the public API.
 
 ## How it works
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,4 @@
 {:deps {clj-kondo/clj-kondo {:mvn/version "2021.10.19"}
-        org.flatland/ordered {:mvn/version "1.15.10"}
         org.clojure/tools.deps.alpha {:mvn/version "0.12.1048"}
         org.slf4j/slf4j-nop {:mvn/version "1.7.30"}}
  :tools/usage

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
 {:deps {clj-kondo/clj-kondo {:mvn/version "2021.10.19"}
+        org.flatland/ordered {:mvn/version "1.15.10"}
         org.clojure/tools.deps.alpha {:mvn/version "0.12.1048"}
         org.slf4j/slf4j-nop {:mvn/version "1.7.30"}}
  :tools/usage

--- a/src/borkdude/api_diff.clj
+++ b/src/borkdude/api_diff.clj
@@ -4,8 +4,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.tools.deps.alpha :as tda]
-   [clojure.tools.deps.alpha.util.maven :as mvn]
-   [flatland.ordered.map :as ordered-map]))
+   [clojure.tools.deps.alpha.util.maven :as mvn]))
 
 (defn path [lib v]
   (let [deps `{:deps {~lib {:mvn/version ~v}} :mvn/repos ~mvn/standard-repos}]
@@ -15,37 +14,40 @@
 
 (defn index-by
   [f coll]
-  (persistent! (reduce #(assoc! %1 (f %2) %2) (transient (ordered-map/ordered-map)) coll)))
+  (persistent! (reduce #(assoc! %1 (f %2) %2) (transient {}) coll)))
 
 (defn group [vars]
   (->> vars
-       (map #(select-keys % [:ns :name :fixed-arities :varargs-min-arity :deprecated :private ::excluded]))
-       (index-by (juxt :ns :name))))
+       (sort-by (juxt :ns :row :col))
+       (map (fn [v]
+              [((juxt :ns :name) v)
+               (select-keys v [:ns :name :fixed-arities :varargs-min-arity :deprecated :private ::excluded])]))))
 
 (defn vars [lib exclude-meta]
-  (if exclude-meta
-    (let [{:keys [namespace-definitions var-definitions]}
-          (-> (clj-kondo/run! {:lint   [lib]
-                               :config {:output
-                                        {:analysis {:var-definitions       {:meta true}
-                                                    :namespace-definitions {:meta true}}
-                                         :format   :edn}}})
-              :analysis)
-          ns-meta-excludes (reduce #(let [m (select-keys (:meta %2) exclude-meta)]
-                                      (if (seq m)
-                                        (assoc %1 (:name %2) m)
-                                        %1))
-                                   {}
-                                   namespace-definitions)]
-      (->> var-definitions
-           (map #(if-let [excluded-by (some-> (merge (:meta %) (get ns-meta-excludes (:ns %)))
-                                              (select-keys exclude-meta)
-                                              seq)]
-                   (assoc % ::excluded (format "meta %s" (vec (keys excluded-by))))
-                   %))))
-    (->> (clj-kondo/run! {:lint   [lib]
-                          :config {:output {:analysis true :format :edn}}})
-         :analysis :var-definitions)))
+  (->> (if exclude-meta
+         (let [{:keys [namespace-definitions var-definitions]}
+               (-> (clj-kondo/run! {:lint   [lib]
+                                    :config {:output
+                                             {:analysis {:var-definitions       {:meta true}
+                                                         :namespace-definitions {:meta true}}
+                                              :format   :edn}}})
+                   :analysis)
+               ns-meta-excludes (reduce #(let [m (select-keys (:meta %2) exclude-meta)]
+                                           (if (seq m)
+                                             (assoc %1 (:name %2) m)
+                                             %1))
+                                        {}
+                                        namespace-definitions)]
+           (->> var-definitions
+                (map #(if-let [excluded-by (some-> (merge (:meta %) (get ns-meta-excludes (:ns %)))
+                                                   (select-keys exclude-meta)
+                                                   seq)]
+                        (assoc % ::excluded (format "meta %s" (vec (keys excluded-by))))
+                        %))))
+         (->> (clj-kondo/run! {:lint   [lib]
+                               :config {:output {:analysis true :format :edn}}})
+              :analysis :var-definitions))
+       (remove #(some #{(:defined-by %)} ['cljs.core/declare 'clojure.core/declare]))))
 
 (defn log-diff [level v  msg]
   (let [{:keys [filename row col ns name]} v]
@@ -62,15 +64,14 @@
                         exclude-meta]}]
   (let [path1 (or (force-os-path-syntax path1) (path lib v1))
         path2 (or (force-os-path-syntax path2) (path lib v2))
-        vars-1 (->> (vars path1 exclude-meta)
-                    (sort-by (juxt :ns :row)))
+        vars-1 (vars path1 exclude-meta)
         vars-2 (vars path2 exclude-meta)
         compare-group-1 (group vars-1)
-        compare-group-2 (group vars-2)
+        compare-group-2-lookup (into {} (group vars-2))
         lookup-1 (index-by (juxt :ns :name) vars-1)]
     (doseq [[k var-1] compare-group-1]
       (when (and (not (:private var-1)) (not (::excluded var-1)))
-        (if-let [var-2 (get compare-group-2 k)]
+        (if-let [var-2 (get compare-group-2-lookup k)]
           (do
             (when (:private var-2)
               (log-diff "error" (get lookup-1 k) "has become private."))

--- a/src/borkdude/api_diff.clj
+++ b/src/borkdude/api_diff.clj
@@ -4,7 +4,8 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.tools.deps.alpha :as tda]
-   [clojure.tools.deps.alpha.util.maven :as mvn]))
+   [clojure.tools.deps.alpha.util.maven :as mvn]
+   [flatland.ordered.map :as ordered-map]))
 
 (defn path [lib v]
   (let [deps `{:deps {~lib {:mvn/version ~v}} :mvn/repos ~mvn/standard-repos}]
@@ -14,11 +15,11 @@
 
 (defn index-by
   [f coll]
-  (persistent! (reduce #(assoc! %1 (f %2) %2) (transient {}) coll)))
+  (persistent! (reduce #(assoc! %1 (f %2) %2) (transient (ordered-map/ordered-map)) coll)))
 
 (defn group [vars]
   (->> vars
-       (map #(select-keys % [:ns :name :fixed-arities :varargs-min-arity :deprecated]))
+       (map #(select-keys % [:ns :name :fixed-arities :varargs-min-arity :deprecated :private ::excluded]))
        (index-by (juxt :ns :name))))
 
 (defn vars [lib exclude-meta]
@@ -26,9 +27,9 @@
     (let [{:keys [namespace-definitions var-definitions]}
           (-> (clj-kondo/run! {:lint   [lib]
                                :config {:output
-                                        {:analysis {:var-definitions {:meta true}
+                                        {:analysis {:var-definitions       {:meta true}
                                                     :namespace-definitions {:meta true}}
-                                         :format :edn}}})
+                                         :format   :edn}}})
               :analysis)
           ns-meta-excludes (reduce #(let [m (select-keys (:meta %2) exclude-meta)]
                                       (if (seq m)
@@ -37,18 +38,18 @@
                                    {}
                                    namespace-definitions)]
       (->> var-definitions
-           (remove :private)
-           (remove #(some-> (merge (:meta %) (get ns-meta-excludes (:ns %)))
-                            (select-keys exclude-meta)
-                            seq))))
+           (map #(if-let [excluded-by (some-> (merge (:meta %) (get ns-meta-excludes (:ns %)))
+                                              (select-keys exclude-meta)
+                                              seq)]
+                   (assoc % ::excluded (format "meta %s" (vec (keys excluded-by))))
+                   %))))
     (->> (clj-kondo/run! {:lint   [lib]
                           :config {:output {:analysis true :format :edn}}})
-         :analysis :var-definitions
-         (remove :private))))
+         :analysis :var-definitions)))
 
-(defn var-symbol [[k v]]
-  (str k "/" v))
-
+(defn log-diff [level v  msg]
+  (let [{:keys [filename row col ns name]} v]
+    (println (str filename ":" row ":" col ": " level ": " ns "/" name " " msg))))
 
 (defn- force-os-path-syntax
   "see https://github.com/clj-kondo/clj-kondo/issues/1438
@@ -59,7 +60,6 @@
 (defn api-diff [{:keys [lib v1 v2
                         path1 path2
                         exclude-meta]}]
-
   (let [path1 (or (force-os-path-syntax path1) (path lib v1))
         path2 (or (force-os-path-syntax path2) (path lib v2))
         vars-1 (->> (vars path1 exclude-meta)
@@ -69,24 +69,23 @@
         compare-group-2 (group vars-2)
         lookup-1 (index-by (juxt :ns :name) vars-1)]
     (doseq [[k var-1] compare-group-1]
-      (if-let [var-2 (get compare-group-2 k)]
-        (let [fixed-arities-v1 (:fixed-arities var-1)
-              fixed-arities-v2 (:fixed-arities var-2)
-              varargs-min-arity (:varargs-min-arity var-2)]
-          (doseq [arity fixed-arities-v1]
-            (when-not (or (contains? fixed-arities-v2 arity)
-                          (and varargs-min-arity (>= arity varargs-min-arity)))
-              (let [{:keys [:filename :row :col]} (get lookup-1 k)]
-                (println (str filename ":" row ":" col ":") "error:"
-                         "Arity" arity "of" (var-symbol k) "was removed."))))
-          (when (and (:deprecated var-2)
-                     (not (:deprecated var-1)))
-            (let [{:keys [:filename :row :col]} (get lookup-1 k)]
-              (println (str filename ":" row ":" col ":") "warning:"
-                       (var-symbol k) "was deprecated."))))
-        (let [{:keys [:filename :row :col]} (get lookup-1 k)]
-          (println (str filename ":" row ":" col ":") "error:"
-                   (var-symbol k) "was removed."))))))
+      (when (and (not (:private var-1)) (not (::excluded var-1)))
+        (if-let [var-2 (get compare-group-2 k)]
+          (do
+            (when (:private var-2)
+              (log-diff "error" (get lookup-1 k) "has become private."))
+            (let [fixed-arities-v1  (:fixed-arities var-1)
+                  fixed-arities-v2  (:fixed-arities var-2)
+                  varargs-min-arity (:varargs-min-arity var-2)]
+              (doseq [arity fixed-arities-v1]
+                (when-not (or (contains? fixed-arities-v2 arity)
+                              (and varargs-min-arity (>= arity varargs-min-arity)))
+                  (log-diff "error" (get lookup-1 k) (format "arity %s was removed." arity)))))
+            (when (and (:deprecated var-2) (not (:deprecated var-1)))
+              (log-diff "warning" (get lookup-1 k) "was deprecated."))
+            (when (::excluded var-2)
+              (log-diff "warning" (get lookup-1 k) (format "now has %s." (::excluded var-2)))))
+          (log-diff "error" (get lookup-1 k) "was removed."))))))
 
 (defn- to-keyword [s]
   (keyword

--- a/test-resources/newer/example.clj
+++ b/test-resources/newer/example.clj
@@ -15,3 +15,7 @@
 (def ^:deprecated z 3)
 
 (defn ^:no-doc nodoc-changes [x y] (+ x y))
+
+;; not marked with skip-wiki in older
+;; arity was 2 in older
+(defn ^:skip-wiki arity-change-and-becomes-skip-wiki [])

--- a/test-resources/newer/example.clj
+++ b/test-resources/newer/example.clj
@@ -19,3 +19,5 @@
 ;; not marked with skip-wiki in older
 ;; arity was 2 in older
 (defn ^:skip-wiki arity-change-and-becomes-skip-wiki [])
+
+(defn ^:private i-was-declared [x y z])

--- a/test-resources/older/example.clj
+++ b/test-resources/older/example.clj
@@ -16,3 +16,8 @@
 (defn ^:skip-wiki skip-wiki [])
 
 (defn arity-change-and-becomes-skip-wiki [x y])
+
+;; declarations should not affect api diff
+(declare i-was-declared)
+
+(defn ^:private i-was-declared [x y z])

--- a/test-resources/older/example.clj
+++ b/test-resources/older/example.clj
@@ -14,3 +14,5 @@
 (defn ^:no-doc nodoc-changes [x] x)
 
 (defn ^:skip-wiki skip-wiki [])
+
+(defn arity-change-and-becomes-skip-wiki [x y])

--- a/test/borkdude/api_diff_test.clj
+++ b/test/borkdude/api_diff_test.clj
@@ -16,21 +16,26 @@
 
 (deftest diff-test
   (testing "libs"
-    (let [out (with-out-str
-                (api-diff/-main ":lib" "clj-kondo/clj-kondo"
-                                ":v1" "2021.09.25"
-                                ":v2" "2021.09.15"))]
-      (is (str/includes? out "clj-kondo.core/config-hash was removed"))))
+    (let [actual-lines (-> (api-diff/-main ":lib" "clj-kondo/clj-kondo"
+                                           ":v1" "2021.09.25"
+                                           ":v2" "2021.09.15")
+                           with-out-str
+                           str/split-lines)]
+      (is (= (osify ["clj_kondo/core.clj:205:1: error: clj-kondo.core/resolve-config was removed."
+                     "clj_kondo/core.clj:213:1: error: clj-kondo.core/config-hash was removed."
+                     "clj_kondo/impl/analyzer.clj:1473:1: error: clj-kondo.impl.analyzer/analyze-ns-unmap was removed."])
+             actual-lines))))
   (testing "paths"
     (let [actual-lines (-> (api-diff/-main ":path1" "test-resources/older"
                                            ":path2" "test-resources/newer")
                            with-out-str
                            str/split-lines)]
-      (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
+      (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private has become private."
                      "test-resources/older/example.clj:11:1: error: example/y was removed."
                      "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
-                     "test-resources/older/example.clj:14:1: error: Arity 1 of example/nodoc-changes was removed."
+                     "test-resources/older/example.clj:14:1: error: example/nodoc-changes arity 1 was removed."
                      "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."
+                     "test-resources/older/example.clj:18:1: error: example/arity-change-and-becomes-skip-wiki arity 2 was removed."
                      "test-resources/older/other.clj:3:1: error: other/other-x was removed."])
              actual-lines)))
     (testing "files"
@@ -38,11 +43,12 @@
                                              ":path2" "test-resources/newer/example.clj")
                              with-out-str
                              str/split-lines)]
-        (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
+        (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private has become private."
                        "test-resources/older/example.clj:11:1: error: example/y was removed."
                        "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
-                       "test-resources/older/example.clj:14:1: error: Arity 1 of example/nodoc-changes was removed."
-                       "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."])
+                       "test-resources/older/example.clj:14:1: error: example/nodoc-changes arity 1 was removed."
+                       "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."
+                       "test-resources/older/example.clj:18:1: error: example/arity-change-and-becomes-skip-wiki arity 2 was removed."])
                actual-lines))))
     (testing "exclude-meta single"
       (let [actual-lines (-> (api-diff/-main ":path1" "test-resources/older"
@@ -50,11 +56,12 @@
                                              ":exclude-meta" ":no-doc")
                              with-out-str
                              str/split-lines)]
-        (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
-                       "test-resources/older/example.clj:8:1: error: example/becomes-nodoc was removed."
+        (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private has become private."
+                       "test-resources/older/example.clj:8:1: warning: example/becomes-nodoc now has meta [:no-doc]."
                        "test-resources/older/example.clj:11:1: error: example/y was removed."
                        "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
-                       "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."])
+                       "test-resources/older/example.clj:16:1: error: example/skip-wiki was removed."
+                       "test-resources/older/example.clj:18:1: error: example/arity-change-and-becomes-skip-wiki arity 2 was removed."])
                actual-lines))))
     (testing "exclude-meta multiple"
       (let [actual-lines (-> (api-diff/-main ":path1" "test-resources/older"
@@ -63,9 +70,11 @@
                                              ":exclude-meta" ":skip-wiki")
                              with-out-str
                              str/split-lines)]
-        (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private was removed."
-                       "test-resources/older/example.clj:8:1: error: example/becomes-nodoc was removed."
+        (is (= (osify ["test-resources/older/example.clj:6:1: error: example/becomes-private has become private."
+                       "test-resources/older/example.clj:8:1: warning: example/becomes-nodoc now has meta [:no-doc]."
                        "test-resources/older/example.clj:11:1: error: example/y was removed."
-                       "test-resources/older/example.clj:12:1: warning: example/z was deprecated."])
+                       "test-resources/older/example.clj:12:1: warning: example/z was deprecated."
+                       "test-resources/older/example.clj:18:1: error: example/arity-change-and-becomes-skip-wiki arity 2 was removed."
+                       "test-resources/older/example.clj:18:1: warning: example/arity-change-and-becomes-skip-wiki now has meta [:skip-wiki]."])
                actual-lines))))))
 ;; => #'borkdude.api-diff-test/diff-test


### PR DESCRIPTION
A var that:
- has become private is logged as an error.
- no longer includes metadata specified by `:exclude-meta`
  is logged as a warning.

To support this change:
- factored out println logging to log-diff fn
  - re-worked arity error msg for consistency
- added flatmap dependency for its ordered map
  - result ordering should now actually be consistent

Closes #13